### PR TITLE
Add Gridfinity Layout Tool to web-based generators

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,6 +266,18 @@
           </p>
         </div>
 
+        <div class="card">
+          <p>
+            <a href="https://gridfinitylayouttool.com">Gridfinity Layout Tool</a>
+            by Andy Aragon, a visual <strong>drawer layout planner</strong> for
+            designing where bins go before you print them.
+          </p>
+          <p>
+            Features include multi-layer support, drag-and-drop bin placement,
+            3D isometric preview, and print optimization with filament estimation.
+          </p>
+        </div>
+
         <div
           class="support-banner-container"
           style="transform: translateY(38px)"


### PR DESCRIPTION
Hi! I'd like to add my tool to the web-based generators section.

**Gridfinity Layout Tool** (https://gridfinitylayouttool.com) is a visual drawer layout planner for designing where bins go before you print them.

Features include:
- Multi-layer support
- Drag-and-drop bin placement
- 3D isometric preview
- Print optimization with filament estimation

Thanks for maintaining this helpful resource!