### PR TITLE
Add TracetoForge to web-based generators

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,6 +217,23 @@
 
         <div class="card">
           <p>
+            <a href="https://tracetoforge.com/">TracetoForge</a> by
+            Chris Winland, a web-based tool for creating
+            <strong>bins</strong> with custom cutouts from a photo.
+          </p>
+          <p>
+            Supports multi-tool trays (up to 5 tools per insert),
+            independent finger notch placement, per-tool bevel and
+            tolerance, and both Gridfinity and custom tray output modes.
+            Free credits on signup; runs entirely in the browser.
+          </p>
+          <p>
+            <span class="non-foss">Proprietary software</span>: not open-source.
+          </p>
+        </div>
+
+        <div class="card">
+          <p>
             <a
               href="https://vector76.github.io/Web_OpenSCAD_Customizer/gridfinity_bins.html"
               >Web OpenSCAD Customizer</a


### PR DESCRIPTION
Adds TracetoForge (tracetoforge.com) to the web-based generators section.

TracetoForge is a browser-based tool that generates Gridfinity inserts from a photo of your tool. Features include multi-tool tray support (up to 5 tools per insert), independent finger notch placement, per-tool bevel and tolerance controls, and both Gridfinity and custom tray output modes. Free credits on signup.

Similar in concept to Georgs' Outline app but with different feature set. Marked as proprietary/non-open-source to match the site's conventions.